### PR TITLE
warnAsError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ More options:
         // Generates XML documentation file (from javadoc through custom DocLet)
         generateDoc = false
 
+        // Whether to handle warnings as errors - not compatible with all IKVM versions
+        // as it was introduced in IKVM 7. If necessary, use the code specific one
+        warnAsError = true
+
+        // Warning codes that should be considered as errors
+        warnAsError = [105, 110, 120]
+
         // Other ikvmc options can be set:
         // fileVersion, target, main, classloader, delaySign, compressResources, removeAssertions, srcPath ...
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,9 @@
 plugins {
     id "nu.studer.plugindev" version "1.0.3"
+    id "com.ullink.functions" version "1.0"
 }
 
 apply plugin: 'groovy'
-
-ext.ullinkGradleScripts = 'https://raw.github.com/gluck/gradle-scripts/master'
-apply from: "${ext.ullinkGradleScripts}/task-rules.gradle"
-apply from: "${ext.ullinkGradleScripts}/functions.gradle"
-
 group = 'com.ullink.gradle'
 version = '2.3'
 description 'gradle-ikvm-plugin is a Gradle plugin for IKVM artifact compilation'

--- a/src/main/groovy/com/ullink/Ikvm.groovy
+++ b/src/main/groovy/com/ullink/Ikvm.groovy
@@ -29,6 +29,7 @@ class Ikvm extends ConventionTask {
     String target
     String main
     String platform
+    def warnAsError
     
     Ikvm() {
         conventionMapping.map "destinationDir", { project.jar.destinationDir }
@@ -163,6 +164,14 @@ class Ikvm extends ConventionTask {
         }
         if (delaySign) {
             commandLineArgs += "-delaysign"
+        }
+        if (warnAsError.any()) {
+            warnAsError.each {
+                commandLineArgs += "-warnaserror:$it"
+            }
+        }
+        else if (warnAsError) {
+            commandLineArgs += "-warnaserror"
         }
 
         commandLineArgs += project.jar.archivePath


### PR DESCRIPTION
- Add a warnAsError option to match the associated IKVM option
May be specified either as a boolean or as a list of values that
will then be used as warning codes to consider as errors
- Removed http imports and use functions plugin for getTools()