### PR TITLE
Fix Gradle 2.6 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile fileTree(dir: "${gradle.gradleHomeDir}/lib/plugins", include: "gradle-plugins-*.jar")
     compile getTools()
     compile 'org.apache.commons:commons-lang3:3.4'
+    compile 'commons-codec:commons-codec:1.10'
     testCompile 'junit:junit:4.8.2'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip


### PR DESCRIPTION
Compile with gradle 2.6 could fix the following issue:

```Caused by: org.gradle.api.GradleException: Could not generate a proxy class for class com.ullink.IkvmDoc.
        at org.gradle.api.internal.AbstractClassGenerator.generateUnderLock(AbstractClassGenerator.java:201)
        at org.gradle.api.internal.AbstractClassGenerator.generate(AbstractClassGenerator.java:64)
        at org.gradle.api.internal.project.taskfactory.TaskFactory.create(TaskFactory.java:115)
        at org.gradle.api.internal.project.taskfactory.TaskFactory.createTask(TaskFactory.java:77)
        at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory.createTask(AnnotationProcessingTaskFactory.java:99)
        at org.gradle.api.internal.project.taskfactory.DependencyAutoWireTaskFactory.createTask(DependencyAutoWireTaskFactory.java:39)
        at org.gradle.api.internal.tasks.DefaultTaskContainer.create(DefaultTaskContainer.java:62)
        at org.gradle.api.internal.project.AbstractProject.task(AbstractProject.java:878)
        at org.gradle.api.Project$task$0.call(Unknown Source)
        at com.ullink.IkvmPlugin.apply(IkvmPlugin.groovy:28)
        at com.ullink.IkvmPlugin.apply(IkvmPlugin.groovy)
        at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOnlyPluginApplicator.java:35)
        at org.gradle.api.internal.plugins.RuleBasedPluginApplicator.applyImperative(RuleBasedPluginApplicator.java:43)
        at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:144)
        ... 61 more
Caused by: java.lang.NoClassDefFoundError: org/gradle/platform/base/internal/toolchain/ToolResolver
        at org.gradle.internal.reflect.ClassInspector.inspectClass(ClassInspector.java:67)
        at org.gradle.internal.reflect.ClassInspector.visitGraph(ClassInspector.java:51)
        at org.gradle.internal.reflect.ClassInspector.inspect(ClassInspector.java:31)
        at org.gradle.api.internal.AbstractClassGenerator.inspectType(AbstractClassGenerator.java:260)
        at org.gradle.api.internal.AbstractClassGenerator.inspectType(AbstractClassGenerator.java:216)
        at org.gradle.api.internal.AbstractClassGenerator.generateUnderLock(AbstractClassGenerator.java:95)
        ... 74 more
Caused by: java.lang.ClassNotFoundException: org.gradle.platform.base.internal.toolchain.ToolResolver```